### PR TITLE
chore: cleanup a few clippy lints

### DIFF
--- a/examples/file_parser.rs
+++ b/examples/file_parser.rs
@@ -31,8 +31,7 @@ fn main() -> io::Result<()> {
         Ok(dbc_content) => println!("DBC Content{dbc_content:#?}"),
         Err(e) => {
             match e {
-                can_dbc::Error::Nom(nom::Err::Error(e)) => eprintln!("{e:?}"),
-                can_dbc::Error::Nom(nom::Err::Failure(e)) => eprintln!("{e:?}"),
+                can_dbc::Error::Nom(nom::Err::Error(e) | nom::Err::Failure(e)) => eprintln!("{e:?}"),
                 can_dbc::Error::Nom(nom::Err::Incomplete(needed)) => eprintln!("Nom incomplete needed: {needed:#?}"),
                 can_dbc::Error::Incomplete(dbc, remaining) => eprintln!("Not all data in buffer was read {dbc:#?}, remaining unparsed (length: {}): {remaining}\n...(truncated)", remaining.len()),
                 can_dbc::Error::MultipleMultiplexors => eprintln!("Multiple multiplexors defined"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,10 +288,10 @@ pub enum MessageId {
 
 impl MessageId {
     /// Raw value of the message id including the bit for extended identifiers
-    pub fn raw(&self) -> u32 {
+    pub fn raw(self) -> u32 {
         match self {
-            MessageId::Standard(id) => u32::from(*id),
-            MessageId::Extended(id) => *id | 1 << 31,
+            MessageId::Standard(id) => u32::from(id),
+            MessageId::Extended(id) => id | 1 << 31,
         }
     }
 }
@@ -732,7 +732,7 @@ impl DBC {
                     None
                 }
             }
-            _ => None,
+            ValueDescription::EnvironmentVariable { .. } => None,
         })
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,6 +4,16 @@
 
 use std::str;
 
+use nom::branch::{alt, permutation};
+use nom::bytes::complete::{escaped, tag, take_till, take_till1, take_while, take_while1};
+use nom::character::complete::{self, char, line_ending, multispace0, one_of, space0, space1};
+use nom::combinator::{map, opt, value};
+use nom::error::{ErrorKind, ParseError};
+use nom::multi::{many0, many_till, separated_list0};
+use nom::number::complete::double;
+use nom::sequence::preceded;
+use nom::{AsChar, IResult, InputTakeAtPosition};
+
 use crate::{
     AccessNode, AccessType, AttributeDefault, AttributeDefinition, AttributeValue,
     AttributeValueForObject, AttributeValuedForObjectType, Baudrate, ByteOrder, Comment, EnvType,
@@ -12,20 +22,9 @@ use crate::{
     SignalExtendedValueType, SignalExtendedValueTypeList, SignalGroups, SignalType, SignalTypeRef,
     Symbol, Transmitter, ValDescription, ValueDescription, ValueTable, ValueType, Version, DBC,
 };
-use nom::bytes::complete::{escaped, take_till1};
-use nom::character::complete::one_of;
-use nom::{
-    branch::{alt, permutation},
-    bytes::complete::{tag, take_till, take_while, take_while1},
-    character::complete::{self, char, line_ending, multispace0, space0, space1},
-    combinator::{map, opt, value},
-    error::{ErrorKind, ParseError},
-    multi::{many0, many_till, separated_list0},
-    number::complete::double,
-    sequence::preceded,
-    AsChar, IResult, InputTakeAtPosition,
-};
 
+// FIXME: move test mod to the end
+#[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -752,6 +751,8 @@ fn message_id(s: &str) -> IResult<&str, MessageId> {
     if parsed_value & (1 << 31) != 0 {
         Ok((s, MessageId::Extended(parsed_value & 0x1FFF_FFFF)))
     } else {
+        // FIXME: use u16::try_from and handle error
+        #[expect(clippy::cast_possible_truncation)]
         Ok((s, MessageId::Standard(parsed_value as u16)))
     }
 }

--- a/tests/cantool-dbcs.rs
+++ b/tests/cantool-dbcs.rs
@@ -1,10 +1,11 @@
 #![cfg(feature = "with-serde")]
 
-use insta::{assert_debug_snapshot, assert_yaml_snapshot, with_settings};
 use std::fs::File;
 use std::io::Read as _;
 use std::path::Path;
 use std::{fs, io};
+
+use insta::{assert_debug_snapshot, assert_yaml_snapshot, with_settings};
 
 /// Test parsing all DBC files in the `tests/cantools-dbcs` directory, using the `can_dbc` crate.
 #[test]


### PR DESCRIPTION
per convention (and one of the lints), tests should be after the code - so a big block move (probably better to do it as a separate PR without any other changes)