### PR TITLE
chore: release v9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.0.0](https://github.com/oxibus/can-dbc/compare/v8.1.0...v9.0.0) - 2026-03-20
+
+### Fixed
+
+- parse signal min/max as `NumericValue` ([#76](https://github.com/oxibus/can-dbc/pull/76))
+- ast/message_id: use 0x1FFF_FFFF (1<<29 - 1) instead of 2^29 in test ([#77](https://github.com/oxibus/can-dbc/pull/77))
+
 ## [8.1.0](https://github.com/oxibus/can-dbc/compare/v8.0.1...v8.1.0) - 2026-01-23
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "can-dbc"
-version = "8.1.0"
+version = "9.0.0"
 description = "A parser for the DBC format. The DBC format is used to exchange CAN network data."
 authors = ["marcelbuesing <buesing.marcel@googlemail.com>"]
 categories = ["embedded", "no-std", "encoding", "parsing"]


### PR DESCRIPTION



## 🤖 New release

* `can-dbc`: 8.1.0 -> 9.0.0 (⚠ API breaking changes)

### ⚠ `can-dbc` breaking changes

```text
--- failure copy_impl_added: type now implements Copy ---

Description:
A public type now implements Copy, causing non-move closures to capture it by reference instead of moving it.
        ref: https://github.com/rust-lang/rust/issues/100905
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/copy_impl_added.ron

Failed in:
  can_dbc::NumericValue in /tmp/.tmpiaRx6y/can-dbc/src/ast/numeric_value.rs:7
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [9.0.0](https://github.com/oxibus/can-dbc/compare/v8.1.0...v9.0.0) - 2026-03-20

### Fixed

- parse signal min/max as `NumericValue` ([#76](https://github.com/oxibus/can-dbc/pull/76))
- ast/message_id: use 0x1FFF_FFFF (1<<29 - 1) instead of 2^29 in test ([#77](https://github.com/oxibus/can-dbc/pull/77))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).