### PR TITLE
chore: release v9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.1.0](https://github.com/oxibus/can-dbc/compare/v9.0.0...v9.1.0) - 2026-05-11
+
+### Added
+
+- support multiple access nodes ([#79](https://github.com/oxibus/can-dbc/pull/79))
+
 ## [9.0.0](https://github.com/oxibus/can-dbc/compare/v8.1.0...v9.0.0) - 2026-03-20
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "can-dbc"
-version = "9.0.0"
+version = "9.1.0"
 description = "A parser for the DBC format. The DBC format is used to exchange CAN network data."
 authors = ["marcelbuesing <buesing.marcel@googlemail.com>"]
 categories = ["embedded", "no-std", "encoding", "parsing"]


### PR DESCRIPTION



## 🤖 New release

* `can-dbc`: 9.0.0 -> 9.1.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [9.1.0](https://github.com/oxibus/can-dbc/compare/v9.0.0...v9.1.0) - 2026-05-11

### Added

- support multiple access nodes ([#79](https://github.com/oxibus/can-dbc/pull/79))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).