### PR TITLE
chore: release v10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- simplify access_nodes and transmitters ([#81](https://github.com/oxibus/can-dbc/pull/81))
+- [**breaking**] simplify access_nodes and transmitters ([#81](https://github.com/oxibus/can-dbc/pull/81))
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.0](https://github.com/oxibus/can-dbc/compare/v9.1.0...v10.0.0) - 2026-07-15
+
+### Added
+
+- simplify access_nodes and transmitters ([#81](https://github.com/oxibus/can-dbc/pull/81))
+
+### Other
+
+- update clippy, just, and other org settings ([#85](https://github.com/oxibus/can-dbc/pull/85))
+- Add DBC attribute lookup methods ([#83](https://github.com/oxibus/can-dbc/pull/83))
+
 ## [9.1.0](https://github.com/oxibus/can-dbc/compare/v9.0.0...v9.1.0) - 2026-05-11
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "can-dbc"
-version = "9.1.0"
+version = "10.0.0"
 description = "A parser for the DBC format. The DBC format is used to exchange CAN network data."
 authors = ["marcelbuesing <buesing.marcel@googlemail.com>"]
 repository = "https://github.com/oxibus/can-dbc"


### PR DESCRIPTION



## 🤖 New release

* `can-dbc`: 9.1.0 -> 10.0.0 (⚠ API breaking changes)

### ⚠ `can-dbc` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum can_dbc::Transmitter, previously in file /tmp/.tmp5RaW5b/can-dbc/src/ast/transmitter.rs:9
  enum can_dbc::AccessNode, previously in file /tmp/.tmp5RaW5b/can-dbc/src/ast/access_node.rs:9

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function can_dbc::decode_cp1252, previously in file /tmp/.tmp5RaW5b/can-dbc/src/parser.rs:14
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [10.0.0](https://github.com/oxibus/can-dbc/compare/v9.1.0...v10.0.0) - 2026-07-15

### Added

- simplify access_nodes and transmitters ([#81](https://github.com/oxibus/can-dbc/pull/81))

### Other

- update clippy, just, and other org settings ([#85](https://github.com/oxibus/can-dbc/pull/85))
- Add DBC attribute lookup methods ([#83](https://github.com/oxibus/can-dbc/pull/83))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).