### PR TITLE
chore: release v11.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0](https://github.com/oxibus/can-dbc/compare/v10.0.0...v11.0.0) - 2026-07-15
+
+### Other
+
+- [**breaking**] remove deprecated with-serde feature ([#86](https://github.com/oxibus/can-dbc/pull/86))
+
 ## [10.0.0](https://github.com/oxibus/can-dbc/compare/v9.1.0...v10.0.0) - 2026-07-15
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "can-dbc"
-version = "10.0.0"
+version = "11.0.0"
 description = "A parser for the DBC format. The DBC format is used to exchange CAN network data."
 authors = ["marcelbuesing <buesing.marcel@googlemail.com>"]
 repository = "https://github.com/oxibus/can-dbc"


### PR DESCRIPTION



## 🤖 New release

* `can-dbc`: 10.0.0 -> 11.0.0 (⚠ API breaking changes)

### ⚠ `can-dbc` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/feature_missing.ron

Failed in:
  feature with-serde in the package's Cargo.toml
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [11.0.0](https://github.com/oxibus/can-dbc/compare/v10.0.0...v11.0.0) - 2026-07-15

### Other

- [**breaking**] remove deprecated with-serde feature ([#86](https://github.com/oxibus/can-dbc/pull/86))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).